### PR TITLE
Ignore backward-sexp error when get completion

### DIFF
--- a/gnuplot.el
+++ b/gnuplot.el
@@ -2990,7 +2990,7 @@ positions and COMPLETIONS is a list."
   (let* ((end (point))
          (beg (condition-case _err
                   (save-excursion (backward-sexp 1) (point))
-                (point)))
+                (error (point))))
          (patt (buffer-substring beg end))
          (pattern (if (string-match "\\([^ \t]*\\)\\s-+$" patt)
                       (match-string 1 patt) patt))


### PR DESCRIPTION
I type `[` in gnuplot script, error occurs via get completion.