### PR TITLE
Deprecate XEmacs support and XEmacs toolbar

### DIFF
--- a/INSTALL.org
+++ b/INSTALL.org
@@ -17,8 +17,7 @@
       instead: see [[Installing without configure or make]] below.
 
       You can specify the Emacs executable to use for byte-compiling
-      by using the ~EMACS~ environment variable: for example
-      ~./configure EMACS=xemacs~ to use XEmacs.  On Mac OS X, if your
+      by using the ~EMACS~ environment variable. On Mac OS X, if your
       Emacs application is located at ~/Applications/Emacs.app~, you
       should do ~./configure
       EMACS=/Applications/Emacs.app/Contents/MacOS/Emacs~

--- a/README.org
+++ b/README.org
@@ -73,9 +73,8 @@ A basic gnuplot configuration can be found below.
    version 4.4 and up. It will also mostly work fine with older
    versions. If it doesn't work with newer versions, report a bug.
 
-   This version has mostly been tested under GNU Emacs 23 and 24.
-   It should also work on GNU Emacs 22 and XEmacs 21. It may work
-   with earlier versions, but it has not been tested.
+   This version has mostly been tested under GNU Emacs 25.
+   It should also work on GNU Emacs 24.3 and above.
 
 *** New syntax for gnuplot version 4
     This version of gnuplot-mode supports the new curly-brace-block

--- a/gnuplot-context.el
+++ b/gnuplot-context.el
@@ -2061,9 +2061,7 @@ there."
 ;; Completions
 (defun gnuplot-completions ()
   (gnuplot-parse-at-point t)
-  (if (featurep 'xemacs)                ; Need an alist
-      (mapcar (lambda (s) (cons s nil)) gnuplot-completions)
-    gnuplot-completions))
+  gnuplot-completions)
 
 (defun gnuplot-context-completion-at-point ()
   "Return completions of keyword preceding point, using context."

--- a/gnuplot-gui.el
+++ b/gnuplot-gui.el
@@ -33,12 +33,8 @@
 ;; backward compatible to 3.5, it will work well for that version
 ;; also.
 ;;
-;; gnuplot-gui.el was developed using Emacs 19.34 and is known to work
-;; on Emacs 20.x and XEmacs 20.x.  I do not know what is the earliest
-;; version for which it will work, but I make no guarantees for
-;; versions before 19.34.  Note that this makes heavy use of the
-;; widget package, so this will not work on Emacs 19.34 unless you
-;; install the widget package separately.
+;; gnuplot-gui.el was developed using GNU Emacs 25 and should be
+;; compatible with GNU Emacs 24.3 and above.
 ;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
@@ -74,7 +70,6 @@
     (error nil)))
 (require 'cl)
 (eval-when-compile          ; suppress some compiler warnings
-  (defvar gnuplot-xemacs-p nil)
   (defvar gnuplot-quote-character nil)
   (defvar gnuplot-info-display nil)
   (defvar gnuplot-mode-map nil))
@@ -115,17 +110,7 @@ This would be done after menu insertion of Gnuplot commands."
 
 (defvar gnuplot-gui-frame nil
   "Frame used to hold the buffer for setting options.")
-(defcustom gnuplot-gui-frame-plist
-  '(height 18 width 65 border-width 0
-           user-position t top 150 left 150
-           internal-border-width 0 unsplittable t
-           default-toolbar-visible-p nil has-modeline-p nil
-           menubar-visible-p nil)
-  "Frame plist for the input run-time display frame in XEmacs."
-  :type '(repeat (group :inline t
-                        (symbol :tag "Property")
-                        (sexp :tag "Value")))
-  :group 'gnuplot-gui)
+
 (defcustom gnuplot-gui-frame-parameters
   '((height . 18)
     (width . 65)
@@ -885,13 +870,10 @@ currently supported."
       (gnuplot-gui-set-options-and-insert))))
 
 (defun gnuplot-gui-get-frame-param (param)
-  (if gnuplot-xemacs-p
-      (plist-get gnuplot-gui-frame-plist param)
-    (cdr (assoc param gnuplot-gui-frame-parameters))))
+  (cdr (assoc param gnuplot-gui-frame-parameters)))
+
 (defun gnuplot-gui-set-frame-param (param value)
-  (if gnuplot-xemacs-p
-      (plist-put gnuplot-gui-frame-plist param value)
-    (setcdr (assoc param gnuplot-gui-frame-parameters) value)))
+  (setcdr (assoc param gnuplot-gui-frame-parameters) value))
 
 (defun gnuplot-gui-set-options-and-insert ()
   "Insert arguments using a GUI interface.
@@ -984,9 +966,7 @@ Note that \"cntrparam\" is not currently supported."
 
 
 (defun gnuplot-gui-y-n (foo))
-(if gnuplot-xemacs-p
-    (defalias 'gnuplot-gui-y-n 'y-or-n-p-maybe-dialog-box)
-  (defalias 'gnuplot-gui-y-n 'y-or-n-p))
+(defalias 'gnuplot-gui-y-n 'y-or-n-p)
 
 (defun gnuplot-gui-correct-command (word set term begin)
   "Check syntax of set command and terminal specifications.
@@ -1281,25 +1261,15 @@ SAVE-FRAME is non-nil when the widgets are being reset."
           gnuplot-current-buffer (current-buffer)
           gnuplot-current-buffer-point (point-marker))
     (unless (and gnuplot-gui-frame (frame-live-p gnuplot-gui-frame))
-      (setq gnuplot-gui-frame (if gnuplot-xemacs-p
-                                  (make-frame gnuplot-gui-frame-plist)
-                                (make-frame gnuplot-gui-frame-parameters))))
+      (setq gnuplot-gui-frame (make-frame gnuplot-gui-frame-parameters)))
     (select-frame gnuplot-gui-frame)
     ;;(set-frame-position gnuplot-gui-frame 150 150) ;; so herky-jerky
-    (if gnuplot-xemacs-p
-        (set-mouse-position (selected-window) 0 0)
-      (set-mouse-position gnuplot-gui-frame 0 0)))
+    (set-mouse-position gnuplot-gui-frame 0 0))
   (kill-buffer (get-buffer-create "*Gnuplot GUI*"))
   (switch-to-buffer (get-buffer-create "*Gnuplot GUI*"))
   (kill-all-local-variables)
-  (if gnuplot-xemacs-p
-      (progn
-        (set (make-local-variable 'frame-title-format)
-             "Set Gnuplot Options")
-        (set (make-local-variable 'frame-icon-title-format)
-             "Set Gnuplot Options"))
-    (modify-frame-parameters (selected-frame)
-                             '((title . "Set Gnuplot Options"))) )
+  (modify-frame-parameters (selected-frame)
+                           '((title . "Set Gnuplot Options")))
   (widget-insert "\nSet options for \"" item "\"  ")
   (let (tag help val)
     (cond ((string-match "^[xyz]2?tics" item)
@@ -1466,8 +1436,7 @@ SAVE-FRAME is non-nil when the widgets are being reset."
                                     (:bold t :foreground "tan"))
                                    (t
                                     (:italic t)))
-  "Face used for push-buttons.
-Only used in Emacs.  XEmacs displays push-buttons with a pixmap."
+  "Face used for push-buttons."
   :group 'gnuplot-faces)
 (defface gnuplot-gui-labels-face '((((class color) (background light))
                                     (:bold t :foreground "darkslateblue"))

--- a/gpelcard.tex
+++ b/gpelcard.tex
@@ -233,9 +233,7 @@ gnuplot-mode.
   \textsc{gnuplot} info file be available and that the info-look
   package be installed.  The info file can be made from the
   documentation supplied with the \textsc{gnuplot} distribution and
-  the info-look package is a standard part of Emacs 20.  Users of
-  XEmacs or Emacs 19 should download \file{info-look.el} from the
-  gnuplot-mode homepage.
+  the info-look package is a standard part of Emacs 20.
 \item[Using pm3d] \hfill \\
   All features of the pm3d patch to \textsc{gnuplot} should be
   available when using gnuplot-mode.  One particularly useful feature
@@ -394,33 +392,6 @@ commands appear in the \texttt{Insertions} menu.
 \variable{gnuplot-insertions-surface-plots}{\Star}{Contents of the
   \texttt{surface plots} sub-menu.}
 
-
-
-\begin{center}
-  \begin{Boxedminipage}{0.75\linewidth}
-    \begin{center}
-      {\large Toolbar variables}
-    \end{center}
-  \end{Boxedminipage}
-\end{center}
-
-\noindent These variables control the use and location of the
-toolbar in XEmacs.  The toolbar has buttons equivalent to the key
-sequences \texttt{C-c C-l}, \texttt{C-c C-r}, \texttt{C-c C-b},
-\texttt{C-c C-e}, and \texttt{C-c C-h}.
-
-\vspace{2ex}
-
-%
-\variable{gnuplot-display-toolbar-flag}{nil}{Non-nil means to display
-  a toolbar if using XEmacs.}
-%
-\variable{gnuplot-use-toolbar}{left-toolbar}{Location of XEmacs
-  toolbar.  Valid values are \texttt{left-toolbar},
-  \texttt{right-toolbar}, \texttt{top-toolbar}, \texttt{bottom-toolbar},
-  \texttt{default-toolbar} and nil.}
-%
-
 \begin{center}
   \begin{Boxedminipage}{0.75\linewidth}
     \begin{center}
@@ -449,9 +420,6 @@ used.}
 \variable{gnuplot-gui-plot-splot-fit-style}{'simple}{\texttt{'simple}
   or \texttt{'complete} -- describes the extent of the list of
   properties of for plot, splot, and fit in the GUI.}
-%
-\variable{gnuplot-gui-frame-plist}{\Star}{Property list of parameters
-  controlling the argument setting frame.  Used by XEmacs.}
 %
 \variable{gnuplot-gui-frame-parameters}{\Star}{List of parameters
   controlling the argument setting frame.  Used by Emacs.}


### PR DESCRIPTION
This is my first attempt at removing support for XEmacs in gnuplot-mode.

These changes are NOT tested, because I haven't yet found a simple way to locally test my changes (I am only getting started in Emacs packages development). However I did not use any functionality to the package, just removed all occurrences of XEmacs, making sure to replace any obsolete functions and variables caused by these changes. I used flycheck and package-lint on the resulting files.

The original commit message is below:

Remove all functions and checks relative to XEmacs, including the
gnuplot-mode toolbar and associated bitmaps.

Mark deprecated modules and functions for future fixes.
