### PR TITLE
Fix completion-at-point functions

### DIFF
--- a/gnuplot-context.el
+++ b/gnuplot-context.el
@@ -2054,23 +2054,11 @@ there."
 
 (defun gnuplot-context-completion-at-point ()
   "Return completions of keyword preceding point, using context."
-  (let* ((end (point))
-         (beg
-          (save-excursion
-            (skip-syntax-backward "w_" (gnuplot-point-at-beginning-of-command))
-            (point)))
-         (word nil)
-         (completions (gnuplot-completions)))
-
-    (setq word (buffer-substring beg end)
-          completions (all-completions word completions))
-
-    (if completions
-        (list beg end completions)
-      (if (not (equal "" word))
-          (message "No gnuplot keywords complete '%s'" word)
-        (message "No completions at point"))
-      nil)))
+  (list (save-excursion
+          (skip-syntax-backward "w_" (gnuplot-point-at-beginning-of-command))
+          (point))
+        (point)
+        (gnuplot-completions)))
 
 ;; Eldoc help
 (defun gnuplot-eldoc-function ()

--- a/gnuplot.el
+++ b/gnuplot.el
@@ -315,7 +315,6 @@ beginning the continued command."
   "A list of keywords used in GNUPLOT.
 These are set by `gnuplot-set-keywords-list' from the values in
 `info-lookup-cache'.")
-(defvar gnuplot-keywords-alist nil) ;; For all-completions
 (defvar gnuplot-keywords-pending t      ;; <HW>
   "A boolean which gets toggled when the info file is probed.")
 (defcustom gnuplot-keywords-when 'deferred ;; 'immediately
@@ -1944,8 +1943,7 @@ See the comments in `gnuplot-info-hook'."
     ;; user will not want them lying around
     (and (get-buffer "info dir")    (kill-buffer "info dir"))
     (and (get-buffer "info dir<2>") (kill-buffer "info dir<2>")))
-  (setq gnuplot-keywords (gnuplot-set-keywords-list))
-  (setq gnuplot-keywords-alist (mapcar 'list gnuplot-keywords)))
+  (setq gnuplot-keywords (gnuplot-set-keywords-list)))
 
 (defun gnuplot-set-keywords-list ()
   "Set `gnuplot-keywords' from `info-lookup-cache'.
@@ -2078,18 +2076,10 @@ positions and COMPLETIONS is a list."
 
   (if gnuplot-keywords-pending          ; <HW>
       (gnuplot-setup-info-look))
-  (let* ((end (point))
-         (beg (condition-case _err
-                  (save-excursion (backward-sexp 1) (point))
-                (error (point))))
-         (patt (buffer-substring beg end))
-         (pattern (if (string-match "\\([^ \t]*\\)\\s-+$" patt)
-                      (match-string 1 patt) patt))
-         (completions (all-completions pattern gnuplot-keywords-alist)))
-    (if completions
-        (list beg end completions)
-      (message "No gnuplot keywords complete '%s'" pattern)
-      nil)))
+  (list (condition-case _err
+            (save-excursion (backward-sexp 1) (point))
+          (error (point)))
+        (point) gnuplot-keywords))
 
 
 (defun gnuplot-info-lookup-symbol (symbol &optional mode)


### PR DESCRIPTION
According to the Emacs documentation the completion functions should not
prefilter the candidates themselves. It is up to the completion UI to perform
the filtering. By deferring the filtering to the completion UI various
completion styles like substring, flex or orderless can be used. In contrast,
the old implementation enforced prefix matching.
